### PR TITLE
Add `deployment_id` input to the `start` step

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,15 @@ deployment tasks you want to do, and it creates and marks a deployment as "start
 The following [`inputs`](https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idstepswith)
 are available:
 
-| Variable      | Default                     | Purpose
-| ------------- | --------------------------- | -------
-| `step`        |                             | must be `start` for this step
-| `token`       |                             | provide your `${{ secrets.GITHUB_TOKEN }}` for API access
-| `logs`        | URL to GitHub commit checks | URL of your deployment logs
-| `desc`        |                             | description for this deployment
-| `env`         |                             | identifier for environment to deploy to (e.g. `staging`, `prod`, `master`)
-| `no_override` | `true`                      | toggle whether to mark existing deployments of this environment as inactive
+| Variable        | Default                     | Purpose
+| --------------- | --------------------------- | -------
+| `step`          |                             | must be `start` for this step
+| `token`         |                             | provide your `${{ secrets.GITHUB_TOKEN }}` for API access
+| `logs`          | URL to GitHub commit checks | URL of your deployment logs
+| `desc`          |                             | description for this deployment
+| `env`           |                             | identifier for environment to deploy to (e.g. `staging`, `prod`, `master`)
+| `no_override`   | `true`                      | toggle whether to mark existing deployments of this environment as inactive
+| `deployment_id` |                             | Use an existing deployment instead of creating a new one (e.g. `${{ github.event.deployment.id }}`)
 
 The following [`outputs`](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#steps-context)
 are available:

--- a/lib/main.js
+++ b/lib/main.js
@@ -37,26 +37,29 @@ function run() {
                     {
                         const environment = core.getInput('env', { required: true });
                         const noOverride = core.getInput('no_override') === 'true';
-                        console.log(`initializing deployment for ${environment}`);
+                        let deploymentID = core.getInput('deployment_id', { required: false });
+                        console.log(`initializing deployment ${deploymentID} for ${environment}`);
                         // mark existing deployments of this environment as inactive
                         if (!noOverride) {
                             yield deactivate_1.default(client, repo, environment);
                         }
                         const transient = core.getInput('transient', { required: false }) === 'true';
-                        const deployment = yield client.repos.createDeployment({
-                            owner: repo.owner,
-                            repo: repo.repo,
-                            ref: ref,
-                            required_contexts: [],
-                            environment,
-                            auto_merge: false,
-                            transient_environment: transient,
-                        });
-                        const deploymentID = deployment.data.id.toString();
+                        if (!deploymentID) {
+                            const deployment = yield client.repos.createDeployment({
+                                owner: repo.owner,
+                                repo: repo.repo,
+                                ref: ref,
+                                required_contexts: [],
+                                environment,
+                                auto_merge: false,
+                                transient_environment: transient,
+                            });
+                            deploymentID = deployment.data.id.toString();
+                        }
                         console.log(`created deployment ${deploymentID} for env ${environment}`);
                         core.setOutput('deployment_id', deploymentID);
                         core.setOutput('env', environment);
-                        yield client.repos.createDeploymentStatus(Object.assign({}, repo, { deployment_id: deployment.data.id, state: 'in_progress', log_url: logsURL || `https://github.com/${repo.owner}/${repo.repo}/commit/${sha}/checks`, description }));
+                        yield client.repos.createDeploymentStatus(Object.assign({}, repo, { deployment_id: parseInt(deploymentID, 10), state: 'in_progress', log_url: logsURL || `https://github.com/${repo.owner}/${repo.repo}/commit/${sha}/checks`, description }));
                         console.log('deployment status set to "in_progress"');
                     }
                     break;


### PR DESCRIPTION
When using this action in the `deployment` event triggered by the Github API, a deployment is already created in the pending state.

This PR allows the user to set the `deployment_id` and skip the `createDeployment` step so the existing deployment is used.
