### PR TITLE
add auto_inactive config

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
   step:
     required: true
     description: One of 'start' and 'finish'
+  auto_inactive:
+    required: false
+    description: Set auto_inactive
   logs:
     required: false
     description: URL to logs

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: One of 'start' and 'finish'
   auto_inactive:
     required: false
-    description: Set auto_inactive
+    description: Set auto_inactive (see https://developer.github.com/v3/repos/deployments/#inactive-deployments)
   logs:
     required: false
     description: URL to logs
@@ -27,4 +27,3 @@ inputs:
   ref:
     required: false
     description: The git ref to use for the deploy, defaults to github.ref
-

--- a/lib/main.js
+++ b/lib/main.js
@@ -28,6 +28,7 @@ function run() {
             const { repo, ref, sha } = github.context;
             const token = core.getInput('token', { required: true });
             const step = core.getInput('step', { required: true });
+            const autoInactive = core.getInput('auto_inactive') !== 'false';
             const logsURL = core.getInput('logs');
             const description = core.getInput('desc');
             const client = new github.GitHub(token, {
@@ -61,7 +62,7 @@ function run() {
                         console.log(`created deployment ${deploymentID} for ${environment} @ ${gitRef}`);
                         core.setOutput('deployment_id', deploymentID);
                         core.setOutput('env', environment);
-                        yield client.repos.createDeploymentStatus(Object.assign(Object.assign({}, repo), { deployment_id: parseInt(deploymentID, 10), state: 'in_progress', log_url: logsURL || `https://github.com/${repo.owner}/${repo.repo}/commit/${sha}/checks`, description }));
+                        yield client.repos.createDeploymentStatus(Object.assign(Object.assign({}, repo), { deployment_id: parseInt(deploymentID, 10), state: 'in_progress', auto_inactive: autoInactive, log_url: logsURL || `https://github.com/${repo.owner}/${repo.repo}/commit/${sha}/checks`, description }));
                         console.log('deployment status set to "in_progress"');
                     }
                     break;
@@ -76,7 +77,7 @@ function run() {
                         }
                         console.log(`finishing deployment for ${deploymentID} with status ${status}`);
                         const newStatus = (status === 'cancelled') ? 'inactive' : status;
-                        yield client.repos.createDeploymentStatus(Object.assign(Object.assign({}, repo), { deployment_id: parseInt(deploymentID, 10), state: newStatus, description, 
+                        yield client.repos.createDeploymentStatus(Object.assign(Object.assign({}, repo), { deployment_id: parseInt(deploymentID, 10), state: newStatus, auto_inactive: autoInactive, description, 
                             // only set environment_url if deployment worked
                             environment_url: (newStatus === 'success') ? envURL : '', 
                             // set log_url to action by default

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ async function run() {
 
     const token = core.getInput('token', { required: true });
     const step = core.getInput('step', { required: true });
+    const autoInactive = core.getInput('auto_inactive') !== 'false';
     const logsURL = core.getInput('logs');
     const description = core.getInput('desc');
 
@@ -52,6 +53,7 @@ async function run() {
           ...repo,
           deployment_id: parseInt(deploymentID, 10),
           state: 'in_progress',
+          auto_inactive: autoInactive,
           log_url: logsURL || `https://github.com/${repo.owner}/${repo.repo}/commit/${sha}/checks`,
           description,
         });
@@ -76,6 +78,7 @@ async function run() {
           ...repo,
           deployment_id: parseInt(deploymentID, 10),
           state: newStatus,
+          auto_inactive: autoInactive,
           description,
 
           // only set environment_url if deployment worked


### PR DESCRIPTION
Github deployment has default `auto_inactive`. 
So all development is inactive except the lastest deployment.

So this action should have has an option to `auto_inactive`

Because somebody wants that every development to be active. 

So we should add to this option to `auto_inactive`.



