### PR TITLE
docs: add missing no_override to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,3 +42,7 @@ inputs:
   status:
     required: false
     description: The deployment status. (For `finish` only)
+  no_override:
+    required: false
+    description: Whether to mark existing deployments of this environment as inactive
+    default: 'true'


### PR DESCRIPTION
The `no_override` option is documented in the README.md and works, but it being missing from `action.yml` generates this annotation on each run:

<img width="1016" alt="Screen Shot 2021-01-18 at 9 57 13 PM" src="https://user-images.githubusercontent.com/458494/104982241-3f048180-59d8-11eb-8c99-d9d81f159c05.png">
