### PR TITLE
set deployment status for other repositories

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,3 +50,6 @@ inputs:
     required: false
     description: Print arguments used by this action.
     default: 'false'
+  repository:
+    required: false
+    description: Set status for a different owner/repository (optional, defaults to the same repo and owner as the action)

--- a/lib/deactivate.js
+++ b/lib/deactivate.js
@@ -9,11 +9,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-function deactivateEnvironment(client, repo, environment) {
+function deactivateEnvironment(client, owner, repo, environment) {
     return __awaiter(this, void 0, void 0, function* () {
         const deployments = yield client.repos.listDeployments({
-            repo: repo.repo,
-            owner: repo.owner,
+            owner,
+            repo,
             environment,
         });
         const existing = deployments.data.length;
@@ -26,7 +26,12 @@ function deactivateEnvironment(client, repo, environment) {
         for (let i = 0; i < existing; i++) {
             const deployment = deployments.data[i];
             console.log(`setting deployment '${environment}.${deployment.id}' (${deployment.sha}) state to "${deadState}"`);
-            yield client.repos.createDeploymentStatus(Object.assign(Object.assign({}, repo), { deployment_id: deployment.id, state: deadState }));
+            yield client.repos.createDeploymentStatus({
+                owner,
+                repo,
+                deployment_id: deployment.id,
+                state: deadState,
+            });
         }
         console.log(`${existing} deployments updated`);
     });

--- a/lib/main.js
+++ b/lib/main.js
@@ -37,12 +37,17 @@ const deactivate_1 = __importDefault(require("./deactivate"));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const { repo, ref, sha } = github.context;
+            const { ref, sha } = github.context;
+            const repositoryConfig = core.getInput("repository");
+            const [owner, repo] = repositoryConfig
+                ? repositoryConfig.split("/")
+                : [github.context.repo.owner, github.context.repo.repo];
+            console.log(`targetting ${owner}/${repo}`);
             const step = core.getInput("step", { required: true });
             const coreArgs = {
                 autoInactive: core.getInput("auto_inactive") !== "false",
                 logsURL: core.getInput("logs") ||
-                    `https://github.com/${repo.owner}/${repo.repo}/commit/${sha}/checks`,
+                    `https://github.com/${owner}/${repo}/commit/${sha}/checks`,
                 description: core.getInput("desc"),
                 logArgs: core.getInput("log_args") === "true",
             };
@@ -60,12 +65,12 @@ function run() {
                         console.log(`initializing deployment ${deploymentID} for ${args.environment} @ ${args.gitRef}`);
                         // mark existing deployments of this environment as inactive
                         if (!args.noOverride) {
-                            yield deactivate_1.default(client, repo, args.environment);
+                            yield deactivate_1.default(client, owner, repo, args.environment);
                         }
                         if (!deploymentID) {
                             const deployment = yield client.repos.createDeployment({
-                                owner: repo.owner,
-                                repo: repo.repo,
+                                owner,
+                                repo,
                                 ref: args.gitRef,
                                 required_contexts: [],
                                 environment: args.environment,
@@ -77,7 +82,15 @@ function run() {
                         console.log(`created deployment ${deploymentID} for ${args.environment} @ ${args.gitRef}`);
                         core.setOutput("deployment_id", deploymentID);
                         core.setOutput("env", args.environment);
-                        yield client.repos.createDeploymentStatus(Object.assign(Object.assign({}, repo), { deployment_id: parseInt(deploymentID, 10), state: "in_progress", auto_inactive: coreArgs.autoInactive, log_url: coreArgs.logsURL, description: coreArgs.description }));
+                        yield client.repos.createDeploymentStatus({
+                            owner,
+                            repo,
+                            deployment_id: parseInt(deploymentID, 10),
+                            state: "in_progress",
+                            auto_inactive: coreArgs.autoInactive,
+                            log_url: coreArgs.logsURL,
+                            description: coreArgs.description,
+                        });
                         console.log('deployment status set to "in_progress"');
                     }
                     break;
@@ -95,11 +108,18 @@ function run() {
                         }
                         console.log(`finishing deployment for ${args.deploymentID} with status ${args.status}`);
                         const newStatus = args.status === "cancelled" ? "inactive" : args.status;
-                        yield client.repos.createDeploymentStatus(Object.assign(Object.assign({}, repo), { deployment_id: parseInt(args.deploymentID, 10), state: newStatus, auto_inactive: args.autoInactive, description: args.description, 
+                        yield client.repos.createDeploymentStatus({
+                            owner,
+                            repo,
+                            deployment_id: parseInt(args.deploymentID, 10),
+                            state: newStatus,
+                            auto_inactive: args.autoInactive,
+                            description: args.description,
                             // only set environment_url if deployment worked
-                            environment_url: newStatus === "success" ? args.envURL : "", 
+                            environment_url: newStatus === "success" ? args.envURL : "",
                             // set log_url to action by default
-                            log_url: args.logsURL }));
+                            log_url: args.logsURL,
+                        });
                         console.log(`${args.deploymentID} status set to ${newStatus}`);
                     }
                     break;
@@ -109,7 +129,7 @@ function run() {
                         if (args.logArgs) {
                             console.log(`'${step}' arguments`, args);
                         }
-                        yield deactivate_1.default(client, repo, args.environment);
+                        yield deactivate_1.default(client, owner, repo, args.environment);
                     }
                     break;
                 default:
@@ -117,7 +137,7 @@ function run() {
             }
         }
         catch (error) {
-            core.setFailed(`unexpected error encounterd: ${error.message}`);
+            core.setFailed(`unexpected error encountered: ${error.message}`);
         }
     });
 }

--- a/src/deactivate.ts
+++ b/src/deactivate.ts
@@ -2,15 +2,13 @@ import * as github from "@actions/github";
 
 async function deactivateEnvironment(
   client: github.GitHub,
-  repo: {
-    owner: string;
-    repo: string;
-  },
+  owner: string,
+  repo: string,
   environment: string
 ) {
   const deployments = await client.repos.listDeployments({
-    repo: repo.repo,
-    owner: repo.owner,
+    owner,
+    repo,
     environment,
   });
   const existing = deployments.data.length;
@@ -30,7 +28,8 @@ async function deactivateEnvironment(
       `setting deployment '${environment}.${deployment.id}' (${deployment.sha}) state to "${deadState}"`
     );
     await client.repos.createDeploymentStatus({
-      ...repo,
+      owner,
+      repo,
       deployment_id: deployment.id,
       state: deadState,
     });


### PR DESCRIPTION
This PR adds an optional `repository` input config, which allows to target other repositories.

The value can be:
- `undefined`: use the current action `owner/repo`
- `repo`: use current owner, and set repo
- `owner/repo`: set both