### PR TITLE
document log_args parameter in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,3 +46,7 @@ inputs:
     required: false
     description: Whether to mark existing deployments of this environment as inactive
     default: 'true'
+  log_args:
+    required: false
+    description: Print arguments used by this action.
+    default: 'false'


### PR DESCRIPTION
As mentioned [here](https://github.com/bobheadxi/deployments/issues/25#issuecomment-807320416).

This should remove the warning when using this argument.

![image](https://user-images.githubusercontent.com/44635962/118410350-463e5200-b68f-11eb-901f-178b80a9044e.png)
