### PR TITLE
[CI-fix] Run tests on PRs too

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - '**'
+  pull_request: {}
 
 jobs:
   checks:


### PR DESCRIPTION
I believe the tests not running in #104 is caused by the `push` tag not working when used with forks.
Setting it to run on `pull_request` should hopefully catch that.