### PR TITLE
doc: correct auto_inactive default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ In addition to the [core configuration](#configuration), the following [`inputs`
 | `deployment_id` |         | identifier for deployment to update (see outputs of [`step: start`](#step-start))                                                                                                                                   |
 | `env_url`       |         | URL to view deployed environment                                                                                                                                                                                    |
 | `override`      | `true`  | whether to manually mark existing deployments of this environment as inactive                                                                                                                                       |
-| `auto_inactive` | `true`  | whether to let GitHub handle marking existing deployments of this environment as inactive ([if and only if a new deployment succeeds](https://docs.github.com/en/rest/reference/deployments#inactive-deployments)). |
+| `auto_inactive` | `false` | whether to let GitHub handle marking existing deployments of this environment as inactive ([if and only if a new deployment succeeds](https://docs.github.com/en/rest/reference/deployments#inactive-deployments)). |
 
 <details>
 <summary>Simple Example</summary>


### PR DESCRIPTION
Seems like the default value for `auto_inactive` flag is `false`, not `true` as documented in the README.

https://github.com/bobheadxi/deployments/blob/88ce5600046c82542f8246ac287d0a53c461bca3/README.md#L173

https://github.com/bobheadxi/deployments/blob/94ff3b2e149ec870b555e1291f39db56b42d0e74/action.yml#L52-L55