### PR TITLE
Allow finish step to update environment name

### DIFF
--- a/src/steps/finish.ts
+++ b/src/steps/finish.ts
@@ -8,6 +8,7 @@ export type FinishArgs = {
   override: boolean;
   status: string;
   envURL?: string;
+  environment?: string;
   autoInactive: boolean;
 };
 
@@ -18,7 +19,7 @@ async function createFinish(
 ) {
   const {
     log,
-    coreArgs: { description, logsURL },
+    coreArgs: { description, logsURL, environment },
   } = context;
   if (stepArgs.override) {
     await deactivateEnvironment(github, context);
@@ -54,6 +55,7 @@ async function createFinish(
     state: newStatus,
     description: description,
     ref: context.ref,
+    environment: environment,
 
     // only set environment_url if deployment worked
     environment_url: newStatus === "success" ? stepArgs.envURL : "",


### PR DESCRIPTION
The API allows for updating the environment name when creating a status: https://docs.github.com/en/rest/deployments/statuses?apiVersion=2022-11-28#create-a-deployment-status