### PR TITLE
Use node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   icon: bookmark
   color: yellow
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 
 inputs:


### PR DESCRIPTION
With the [deprecation notice](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) from Github due to Node 16 reaching EOF , i'm updating the action configuration to use Node 20 instead